### PR TITLE
Feat : 댓글 관련 API 구현, createdAt 출력 시간 UTC -> KST 변경

### DIFF
--- a/prisma/client.js
+++ b/prisma/client.js
@@ -2,6 +2,31 @@ import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
-export default prisma;
+// 미들웨어 추가: 모든 조회 작업에서 createdAt 필드를 9시간 더한 후 ISO 형식으로 반환
+prisma.$use(async (params, next) => {
+    const result = await next(params);
 
-// PrsimaClient가 필요할때마다 import해서 쓰면 됨
+    // 조회 작업만 시간 변환 적용
+    if (['findUnique', 'findMany', 'findFirst'].includes(params.action)) {
+        const addNineHours = (date) => {
+            const kstTime = new Date(new Date(date).getTime() + 9 * 60 * 60 * 1000);
+            return kstTime.toISOString();
+        };
+
+        if (Array.isArray(result)) {
+            result.forEach(item => {
+                if (item.createdAt) {
+                    item.createdAt = addNineHours(item.createdAt);
+                }
+            });
+        } else {
+            if (result && result.createdAt) {
+                result.createdAt = addNineHours(result.createdAt);
+            }
+        }
+    }
+
+    return result;
+});
+
+export default prisma;

--- a/prisma/migrations/20240824225052_add_password_to_comments/migration.sql
+++ b/prisma/migrations/20240824225052_add_password_to_comments/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `commentPassword` to the `Comments` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Comments" ADD COLUMN     "commentPassword" TEXT NOT NULL;

--- a/prisma/migrations/20240824225918_change_post_password_to_password/migration.sql
+++ b/prisma/migrations/20240824225918_change_post_password_to_password/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `commentPassword` on the `Comments` table. All the data in the column will be lost.
+  - Added the required column `password` to the `Comments` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Comments" DROP COLUMN "commentPassword",
+ADD COLUMN     "password" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,6 +51,7 @@ model Comments {
   id        String   @id @default(uuid())
   nickname  String
   content   String
+  password  String
   createdAt DateTime @default(now())
   post      Posts    @relation(fields: [postId], references: [id]) // 댓글 - 게시글 다대일 관계
   postId    String

--- a/src/app.js
+++ b/src/app.js
@@ -3,6 +3,7 @@ dotenv.config();
 import express from 'express';
 import groupRouter from './routers/groupRouter.js'
 import postRouter from './routers/postRouter.js'
+import commentRouter from './routers/commentRouter.js'
 import { errorHandler } from './middlewares/errorHandler.js';
 
 const app = express();
@@ -10,6 +11,7 @@ app.use(express.json());
 
 app.use('/api/groups', groupRouter);
 app.use('/api/posts', postRouter);
+app.use('/api/comments', commentRouter);
 
 // 전역 오류 처리 미들웨어
 app.use(errorHandler);

--- a/src/controllers/commentController.js
+++ b/src/controllers/commentController.js
@@ -1,3 +1,36 @@
 import prisma from "../../prisma/client.js";
 import { asyncHandler } from '../middlewares/asyncHandler.js';
 import { assert } from 'superstruct';
+import { PatchComment } from "../structs.js";
+
+/* -------------------- 댓글 수정 -------------------- */
+export const EditComment = asyncHandler(async (req, res) => {
+    const { commentId } = req.params;
+
+    // 유효성 검사 수행
+    assert(req.body, PatchComment);
+
+    // 댓글 비밀번호를 제외한 나머지 업데이트 정보를 updateData에 저장
+    const { password, ...updateData } = req.body;
+
+    const comment = await prisma.comments.findUniqueOrThrow({
+        where: { id: commentId }
+    });
+
+    if (comment.password !== password) {
+        throw { name: 'ForbiddenError' };
+    }
+
+    const newComment = await prisma.comments.update({
+        where: { id: commentId },
+        data: updateData,
+        select: {
+            id: true,
+            nickname: true,
+            content: true,
+            createdAt: true
+        }
+    });
+
+    res.status(200).json(newComment);
+})

--- a/src/controllers/commentController.js
+++ b/src/controllers/commentController.js
@@ -1,0 +1,3 @@
+import prisma from "../../prisma/client.js";
+import { asyncHandler } from '../middlewares/asyncHandler.js';
+import { assert } from 'superstruct';

--- a/src/controllers/commentController.js
+++ b/src/controllers/commentController.js
@@ -4,7 +4,7 @@ import { assert } from 'superstruct';
 import { PatchComment } from "../structs.js";
 
 /* -------------------- 댓글 수정 -------------------- */
-export const EditComment = asyncHandler(async (req, res) => {
+export const editComment = asyncHandler(async (req, res) => {
     const { commentId } = req.params;
 
     // 유효성 검사 수행
@@ -33,4 +33,30 @@ export const EditComment = asyncHandler(async (req, res) => {
     });
 
     res.status(200).json(newComment);
+});
+
+
+/* -------------------- 댓글 삭제 -------------------- */
+export const deleteComment = asyncHandler(async (req, res) => {
+    const { commentId } = req.params;
+    const { password } = req.body;
+
+    const comment = await prisma.comments.findUniqueOrThrow({
+        where: { id: commentId }
+    });
+
+    if (comment.password !== password) {
+        throw { name: 'ForbiddenError' };
+    }
+
+    await prisma.comments.delete({
+        where: { id: commentId }
+    });
+
+    await prisma.posts.update({
+        where: { id: comment.postId },
+        data: { commentCount: { decrement: 1 } }
+    });
+
+    res.status(200).json({ message: '답글 삭제 성공' });
 })

--- a/src/controllers/postController.js
+++ b/src/controllers/postController.js
@@ -138,7 +138,7 @@ export const isPostPublic = asyncHandler(async (req, res) => {
 
 
 /* -------------------- 댓글 등록 -------------------- */
-export const createPost = asyncHandler(async (req, res) => {
+export const createComment = asyncHandler(async (req, res) => {
     const { postId } = req.params;
     const { nickname, content, password } = req.body;
 

--- a/src/controllers/postController.js
+++ b/src/controllers/postController.js
@@ -1,7 +1,7 @@
 import prisma from "../../prisma/client.js";
 import { asyncHandler } from '../middlewares/asyncHandler.js';
 import { assert } from 'superstruct';
-import { PatchPost } from "../structs.js";
+import { PatchPost, CreatedComment } from "../structs.js";
 
 /* -------------------- 게시글 수정 -------------------- */
 export const editPost = asyncHandler(async (req, res) => {
@@ -141,6 +141,8 @@ export const isPostPublic = asyncHandler(async (req, res) => {
 export const createPost = asyncHandler(async (req, res) => {
     const { postId } = req.params;
     const { nickname, content, password } = req.body;
+
+    assert(req.body, CreatedComment);
 
     await prisma.posts.findUniqueOrThrow({
         where: { id: postId },

--- a/src/controllers/postController.js
+++ b/src/controllers/postController.js
@@ -135,3 +135,38 @@ export const isPostPublic = asyncHandler(async (req, res) => {
 
     res.status(200).json(post);
 })
+
+/* -------------------- 댓글 등록 -------------------- */
+export const createPost = asyncHandler(async (req, res) => {
+    const { postId } = req.params;
+    const { nickname, content, password } = req.body;
+
+    await prisma.posts.findUniqueOrThrow({
+        where: { id: postId },
+    });
+
+    // 댓글 생성
+    const newComment = await prisma.comments.create({
+        data: {
+            nickname,
+            content,
+            password,
+            postId,  // 댓글을 해당 게시글에 연결
+        },
+        select: {
+            id: true,
+            nickname: true,
+            content: true,
+            createdAt: true,
+        },
+    });
+
+    // 게시글의 commentCount 증가
+    await prisma.posts.update({
+        where: { id: postId },
+        data: { commentCount: { increment: 1 } }
+    });
+
+    res.status(201).json(newComment);
+
+})

--- a/src/routers/commentRouter.js
+++ b/src/routers/commentRouter.js
@@ -1,0 +1,9 @@
+import express from 'express';
+import { EditComment } from '../controllers/commentController.js';
+
+const router = express.Router();
+
+router.patch('/:commentId', EditComment); // 댓글 수정
+
+
+export default router;

--- a/src/routers/commentRouter.js
+++ b/src/routers/commentRouter.js
@@ -1,9 +1,10 @@
 import express from 'express';
-import { EditComment } from '../controllers/commentController.js';
+import { editComment, deleteComment } from '../controllers/commentController.js';
 
 const router = express.Router();
 
-router.patch('/:commentId', EditComment); // 댓글 수정
+router.patch('/:commentId', editComment); // 댓글 수정
+router.delete('/:commentId', deleteComment); // 댓글 삭제
 
 
 export default router;

--- a/src/routers/postRouter.js
+++ b/src/routers/postRouter.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { editPost, deletePost, getPostDetail, verifyPostAccess, likePost, isPostPublic, createPost, getCommentList} from '../controllers/postController.js';
+import { editPost, deletePost, getPostDetail, verifyPostAccess, likePost, isPostPublic, createComment, getCommentList} from '../controllers/postController.js';
 
 
 const router = express.Router();
@@ -11,7 +11,7 @@ router.post('/:postId/verify-password', verifyPostAccess); // 게시글 조회 �
 router.post('/:postId/like', likePost); // 게시글 공감하기
 router.post('/:postId/is-public', isPostPublic); // 게시글 공개 여부 확인
 
-router.post('/:postId/comments', createPost); // 댓글 작성
+router.post('/:postId/comments', createComment); // 댓글 작성
 router.get('/:postId/comments', getCommentList); // 댓글 목록 조회
 
 export default router;

--- a/src/routers/postRouter.js
+++ b/src/routers/postRouter.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { editPost, deletePost, getPostDetail, verifyPostAccess, likePost, isPostPublic } from '../controllers/postController.js';
+import { editPost, deletePost, getPostDetail, verifyPostAccess, likePost, isPostPublic, createPost} from '../controllers/postController.js';
 
 
 const router = express.Router();
@@ -11,5 +11,5 @@ router.post('/:postId/verify-password', verifyPostAccess); // 게시글 조회 �
 router.post('/:postId/like', likePost); // 게시글 공감하기
 router.post('/:postId/is-public', isPostPublic); // 게시글 공개 여부 확인
 
-
+router.post('/:postId/comments', createPost); // 게시글 작성
 export default router;

--- a/src/routers/postRouter.js
+++ b/src/routers/postRouter.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { editPost, deletePost, getPostDetail, verifyPostAccess, likePost, isPostPublic, createPost} from '../controllers/postController.js';
+import { editPost, deletePost, getPostDetail, verifyPostAccess, likePost, isPostPublic, createPost, getCommentList} from '../controllers/postController.js';
 
 
 const router = express.Router();
@@ -11,5 +11,7 @@ router.post('/:postId/verify-password', verifyPostAccess); // 게시글 조회 �
 router.post('/:postId/like', likePost); // 게시글 공감하기
 router.post('/:postId/is-public', isPostPublic); // 게시글 공개 여부 확인
 
-router.post('/:postId/comments', createPost); // 게시글 작성
+router.post('/:postId/comments', createPost); // 댓글 작성
+router.get('/:postId/comments', getCommentList); // 댓글 목록 조회
+
 export default router;


### PR DESCRIPTION
## 작업 내용
1. 댓글 등록, 댓글 목록 조회, 댓글 수정, 댓글 삭제 총 4개 API 구현 완료 했습니다.
2. DB모델의 comments에 password가 빠져있어서 추가했습니다.
3. DB가 UTC로 맞춰져 있어서 createdAt이 한국 시간과 맞지 않았습니다. client.js 파일에 미들웨어를 설정해서 response로 createdAt 정보를 넘겨줄때 KST로 바뀌도록 했습니다.
'findUnique', 'findMany', 'findFirst' 와 같은 조회 작업을 할 때 UTC 시간 + 9시간을 해서 넘겨주는 방식입니다. 조회 결과가 객체일때 / 배열일때 두가지 경우로 나눠서 코드를 짰습니다!
## 리뷰어에게 부탁할 내용
오류 있으면 알려주세요!
## 스크린샷 (필요시)
## 기타