### PR TITLE
Fix : 7일 연속 게시글 등록 여부 확인 알고리즘에서 post.createdAt를 Date 객체로 변경하여 오류 해결

### DIFF
--- a/src/controllers/groupController.js
+++ b/src/controllers/groupController.js
@@ -330,7 +330,7 @@ export const createPost = asyncHandler(async (req, res) => {
 
   // 7일 연속 게시글 등록 여부 확인
   let isConsecutive = true;
-  const uniqueDates = new Set(recentPosts.map(post => post.createdAt.toISOString().split('T')[0])); // "YYYY-MM-DD" 형식으로 날짜만 추출하여 Set에 추가
+  const uniqueDates = new Set(recentPosts.map(post => new Date(post.createdAt).toISOString().split('T')[0])); // "YYYY-MM-DD" 형식으로 날짜만 추출하여 Set에 추가
 
   // 날짜 비교
   if (uniqueDates.size === 7) {


### PR DESCRIPTION
## 작업 내용
`post.createdAt`을 Date객체로 만들어서 `.toISOString()`에서 발생하는 TypeError를 해결했습니다.
## 리뷰어에게 부탁할 내용
## 스크린샷 (필요시)
## 기타